### PR TITLE
renamed service cluster to remove eero's name

### DIFF
--- a/dashbase-service/conf/config.yml
+++ b/dashbase-service/conf/config.yml
@@ -1,5 +1,5 @@
 cluster:
-  name: 'dashbase-eero'
+  name: 'dashbase-service'
   url: localhost:2181
 server:
   applicationConnectors:


### PR DESCRIPTION
eero's name was the cluster name. this should not be the case for our example repo.